### PR TITLE
24.x-rebase: fix test suite

### DIFF
--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -142,7 +142,7 @@ FUZZ_TARGET(string)
     BlockFilterType block_filter_type;
     (void)BlockFilterTypeByName(random_string_1, block_filter_type);
     (void)Capitalize(random_string_1);
-    (void)CopyrightHolders(random_string_1);
+    (void)CopyrightHolders(random_string_1, random_string_2);
     FeeEstimateMode fee_estimate_mode;
     (void)FeeModeFromString(random_string_1, fee_estimate_mode);
     const auto width{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 1000)};


### PR DESCRIPTION
This PR updates test suite 'string.cpp' to support the second copyright holder that is used in Vertcoin Core.