### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ mining power.
  - 2.5 minute block targets
  - Subsidy halves in 840k blocks (~4 years)
  - 84 million total coins
- - 12.5 coins per block 
+ - 6.25 coins per block 
  - Difficulty retargeting every block to recover from large hashrate swings
  - Verthash proof of work algorithm for ASIC resistance
 


### PR DESCRIPTION
updated outdated block reward to new correct block reward, as of block 2,520,000 hashed at 12/8/25 (December 8th 2025), 14:21:44, block reward has been halved from 12.5 vtc to 6.25 vtc